### PR TITLE
Added xmlsec1for SAML feature

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -19,7 +19,7 @@ LABEL maintainer="Jacob Danell <jacob@emberlight.se>"
 USER root
 
 RUN apt update \
-    && apt install -y --no-install-recommends ffmpeg bzip2 postgresql-client \
+    && apt install -y --no-install-recommends ffmpeg bzip2 postgresql-client xmlsec1 \
     && apt autoclean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/sample.env
+++ b/sample.env
@@ -19,6 +19,11 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=Un53cur3Pa55w0rd
 POSTGRES_DB=zoudb
 
+# SAML options
+#SAML_ENABLED=True
+#SAML_IDP_NAME="IDP NAME (Will be visible on the login page.)"
+#SAML_METADATA_URL="YOUR SAML METADATA URL"
+
 # Email options
 #MAIL_SERVER=smtp.gmail.com
 #MAIL_PORT=587


### PR DESCRIPTION
The new SAML feature added to Zou uses pysaml2 which requires xmlsec1.

Currently when the three environment variables are set for SAML:
- SAML_ENABLED
- SAML_IDP_NAME
- SAML_METADATA_URL 

All containers which use this image fail with the following error - 
![image](https://github.com/user-attachments/assets/8df6c37b-5417-4397-b7d1-2ec94d43c9f6)

After adding xmlsec1 all containers run normally with the error no longer appearing.


